### PR TITLE
Moving stage and region overrides under provider

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -22,7 +22,10 @@ provider:
   runtime: nodejs6.10
   # If you want to change to a different AWS profile
   # from ~/.aws/credentials, you can do so here
-  profile: default 
+  profile: default
+  # you can overwrite defaults here
+  #  stage: dev
+  #  region: us-east-1
 
 plugins:
   - serverless-webpack
@@ -30,9 +33,7 @@ plugins:
 custom:
   webpackIncludeModules: true
 
-# you can overwrite defaults here
-#  stage: dev
-#  region: us-east-1
+
 
 # you can add statements to the Lambda function's IAM Role here
 #  iamRoleStatements:


### PR DESCRIPTION
Refer to `provider` variables here: https://serverless.com/framework/docs/providers/aws/guide/credentials#setup-with-the-aws-cli

Global overrides may no longer work, or may require direct reference to provider block after initial deploy, but either way moving them per updates here made them work a treat!

Thanks again for the starter.

