### PR TITLE
Fix error caused by non-ts-aware configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,15 @@ module.exports = {
     sourceType: 'module',
   },
   env: { jest: true, browser: true, node: true },
-  rules: { 'no-console': 'warn' },
+  rules: {
+    'no-console': 'warn',
+    'import/extensions': ['error', 'ignorePackages', {
+      ts: 'never',
+      tsx: 'never',
+      js: 'never',
+      jsx: 'never',
+    }],
+  },
   settings: {
     'import/resolver': {
       node: {


### PR DESCRIPTION
Currently the lint command is failing due to https://github.com/benmosher/eslint-plugin-import/issues/1615. This PR fixes it by applying https://github.com/benmosher/eslint-plugin-import/pull/1637.