### PR TITLE
Fix conflicting rules between prettier and eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
-  extends: ['prettier', 'airbnb'],
+  extends: ['airbnb', 'prettier'],
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',


### PR DESCRIPTION
Had some trouble with conflicting rules between prettier and eslint, which caused my CI to fail after the linting pre-commit hooks had run, something that shouldn't happen, given that eslint-config-prettier is installed. After digging a bit into it, it turns out that the problem is caused by the order in which the two rulesets are being imported in the eslint configuration file, which this PR fixes.